### PR TITLE
fix(views): meta tag "keywords"

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Comunidad IT</title>
     <meta name="description" content="Encuentra la mejor comunidad de CS y tecnologia">
-    <meta name="keywords" content="developers comunidad it desarollo programacion">
+    <meta name="keywords" content="developers, comunidad, it, desarollo, programacion">
     <meta property="og:title" content="Comunidad IT | Landing Page" />
     <meta property="og:description" content="Encuentra la mejor comunidad de CS y tecnologia" />
 


### PR DESCRIPTION
Se arregla el contenido del atributo `content` de la meta tag "keywords".

La sintaxis correcta para la meta tag keyword es una lista de terminos separados por comas,
anteriormente los terminos no tenian tal separacion, y debio a eso, este commit arregla eso.